### PR TITLE
Update Notary framework to use theupdateframework

### DIFF
--- a/update.sh
+++ b/update.sh
@@ -13,13 +13,13 @@ done
 DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
 
 # build the binaries
-cd $GOPATH/src/github.com/docker/notary
+cd $GOPATH/src/github.com/theupdateframework/notary
 make static
 
 cd $DIR
 
-cp $GOPATH/src/github.com/docker/notary/bin/static/notary-server ./notary-server
-cp $GOPATH/src/github.com/docker/notary/bin/static/notary-signer ./notary-signer
+cp $GOPATH/src/github.com/theupdateframework/notary/bin/static/notary-server ./notary-server
+cp $GOPATH/src/github.com/theupdateframework/notary/bin/static/notary-signer ./notary-signer
 
 # return user to original location
 cd $ORIG


### PR DESCRIPTION
- Update Script to use the new officially supported framework.
- Update script to fetch the latest code and build binaries according to the host.

The changes are verified on both ```amd64 & arm64v8``` architectures.
The script generated new static binaries for both architectures and docker was also running fine.

By taking this change, Notary can be extended to ```arm64v8``` architecture as well.