### PR TITLE
Allow building the signer from source whilst still keeping container size down

### DIFF
--- a/notary-signer/Dockerfile
+++ b/notary-signer/Dockerfile
@@ -1,27 +1,36 @@
-FROM golang:1.10.3-alpine
+FROM alpine:latest
+
 ENV TAG v0.6.1
 ENV NOTARYPKG github.com/theupdateframework/notary
-WORKDIR /go/src/${NOTARYPKG}
-RUN apk --update add tar
-RUN wget -O notary.tar.gz "https://api.github.com/repos/theupdateframework/notary/tarball/${TAG}" && tar xzf notary.tar.gz --strip-components=1
-# Since we are not using git to get the repo, use the REST API to get the sha of the digest for the tag.
-RUN go install \
-    -ldflags "-w -X ${NOTARYPKG}/version.GitCommit=`wget -qO- https://api.github.com/repos/theupdateframework/notary/tags | grep -A 5 ${TAG} | grep sha | awk '{print substr($2,2,8)}'` -X ${NOTARYPKG}/version.NotaryVersion=`cat NOTARY_VERSION`" \
-    ${NOTARYPKG}/cmd/notary-signer
-
-
-FROM alpine:latest
+ENV NOTARYREPO https://api.github.com/repos/theupdateframework/notary
+ENV INSTALLDIR /notary/signer
 EXPOSE 4444
 EXPOSE 7899
-WORKDIR /notary/signer
+
+WORKDIR /usr/lib/go/src/${NOTARYPKG}
+
+RUN apk --no-cache add tar go musl-dev && \
+    wget -O notary.tar.gz "${NOTARYREPO}/tarball/${TAG}" && \
+    tar xzf notary.tar.gz --strip-components=1 && \
+    go install \
+	-ldflags "-w -X ${NOTARYPKG}/version.GitCommit=`wget -qO- ${NOTARYREPO}/tags | \
+	    grep -A 5 ${TAG} | grep sha | \
+	    awk '{print substr($2,2,8)}'` \
+	    -X ${NOTARYPKG}/version.NotaryVersion=`cat NOTARY_VERSION`" \
+	${NOTARYPKG}/cmd/notary-signer && \
+    mkdir -p ${INSTALLDIR} && \
+    cp /usr/lib/go/bin/notary-signer ${INSTALLDIR} && \
+    apk --no-cache del tar go musl-dev && \
+    rm -rf /usr/lib/go
+
+WORKDIR ${INSTALLDIR}
 
 COPY ./signer-config.json .
 COPY ./entrypoint.sh .
-COPY --from=0 /go/bin/notary-signer .
 
 RUN adduser -D -H -g "" notary
 USER notary
-ENV PATH=$PATH:/notary/signer
+ENV PATH=$PATH:${INSTALLDIR}
 
 ENTRYPOINT [ "entrypoint.sh" ]
 CMD [ "notary-signer", "--help" ]


### PR DESCRIPTION
Fixes: #7 
Fixes: https://github.com/docker-library/official-images/pull/4718 
Fixes: https://github.com/theupdateframework/notary/issues/1380

Commit 3246cae356f2 (Notary 0.6.1, and rather than commit binaries,
build using multistage dockerfiles.) provided support for building
binaries from source, instead of introducing them into the repo. It
also introduced multi-stage builds into the project.

Multi-stage builds allow us to supply all of the build requirements
into disposable build-containers.  Once finished with, only the
required build artifacts are copied out into a nice succinct run-
container.  This results in a container with a much smaller
footprint.

The issue is; Docker's Official Images platform does not yet support
multi-stage builds.  So until they do, we need to find a source of
compromise.

Here we start with a small base (Alpine), install only the build
requirements we need, build from source, then once complete clean-up
any unnecessary packages.  This both allows for building from source
AND keeps the final run-container nice and small.

Signed-off-by: Lee Jones <lee.jones@linaro.org>