### PR TITLE
Update build to Go 1.10.8 so it completes successfully again

### DIFF
--- a/notary-server/Dockerfile
+++ b/notary-server/Dockerfile
@@ -9,7 +9,7 @@ WORKDIR ${INSTALLDIR}
 
 RUN set -eux; \
     apk add --no-cache --virtual build-deps git go make musl-dev; \
-    go version | grep 'go1.10.7 '; \
+    go version | grep 'go1.10.8 '; \
     export GOPATH=/go GOCACHE=/go/cache; \
     mkdir -p ${GOPATH}/src/${NOTARYPKG}; \
     git clone -b ${TAG} --depth 1 https://${NOTARYPKG} ${GOPATH}/src/${NOTARYPKG}; \

--- a/notary-signer/Dockerfile
+++ b/notary-signer/Dockerfile
@@ -10,7 +10,7 @@ WORKDIR ${INSTALLDIR}
 
 RUN set -eux; \
     apk add --no-cache --virtual build-deps git go make musl-dev; \
-    go version | grep 'go1.10.7 '; \
+    go version | grep 'go1.10.8 '; \
     export GOPATH=/go GOCACHE=/go/cache; \
     mkdir -p ${GOPATH}/src/${NOTARYPKG}; \
     git clone -b ${TAG} --depth 1 https://${NOTARYPKG} ${GOPATH}/src/${NOTARYPKG}; \


### PR DESCRIPTION
See https://pkgs.alpinelinux.org/package/v3.8/community/x86_64/go, which has since updated to Go 1.10.8. :+1: