### PR TITLE
Update alpine 3.10, Go 1.12.6

### DIFF
--- a/notary-server/Dockerfile
+++ b/notary-server/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.8
+FROM alpine:3.10
 
 ENV TAG v0.6.1
 ENV NOTARYPKG github.com/theupdateframework/notary
@@ -9,11 +9,11 @@ WORKDIR ${INSTALLDIR}
 
 RUN set -eux; \
     apk add --no-cache --virtual build-deps git go make musl-dev; \
-    go version | grep 'go1.10.8 '; \
+    go version | grep 'go1.12.8 '; \
     export GOPATH=/go GOCACHE=/go/cache; \
     mkdir -p ${GOPATH}/src/${NOTARYPKG}; \
     git clone -b ${TAG} --depth 1 https://${NOTARYPKG} ${GOPATH}/src/${NOTARYPKG}; \
-    make -C ${GOPATH}/src/${NOTARYPKG} PREFIX=. ./bin/static/notary-server; \
+    make -C ${GOPATH}/src/${NOTARYPKG} SKIPENVCHECK=1 PREFIX=. ./bin/static/notary-server; \
     cp -vL ${GOPATH}/src/${NOTARYPKG}/bin/static/notary-server ./; \
     apk del --no-network build-deps; \
     rm -rf ${GOPATH}

--- a/notary-signer/Dockerfile
+++ b/notary-signer/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.8
+FROM alpine:3.10
 
 ENV TAG v0.6.1
 ENV NOTARYPKG github.com/theupdateframework/notary
@@ -10,11 +10,11 @@ WORKDIR ${INSTALLDIR}
 
 RUN set -eux; \
     apk add --no-cache --virtual build-deps git go make musl-dev; \
-    go version | grep 'go1.10.8 '; \
+    go version | grep 'go1.12.8 '; \
     export GOPATH=/go GOCACHE=/go/cache; \
     mkdir -p ${GOPATH}/src/${NOTARYPKG}; \
     git clone -b ${TAG} --depth 1 https://${NOTARYPKG} ${GOPATH}/src/${NOTARYPKG}; \
-    make -C ${GOPATH}/src/${NOTARYPKG} PREFIX=. ./bin/static/notary-signer; \
+    make -C ${GOPATH}/src/${NOTARYPKG} SKIPENVCHECK=1 PREFIX=. ./bin/static/notary-signer; \
     cp -vL ${GOPATH}/src/${NOTARYPKG}/bin/static/notary-signer ./; \
     apk del --no-network build-deps; \
     rm -rf ${GOPATH}


### PR DESCRIPTION
~Unfortunately, Go 1.12.8 is not available yet on alpine, so we may want to wait on that?~

Go 1.12.8 is available now on `alpine:3.10` and `alpine:edge`;

```bash
docker build --pull -<<EOF
FROM alpine:3.10
RUN RUN apk add --quiet --no-cache go  && go version  && exit 1
EOF
```

```
------                                                                                                                                                                                                                                                                                        
 > [2/2] RUN apk add --quiet --no-cache go  && go version  && exit 1:
#5 23.61 go version go1.12.8 linux/amd64
------
```