### PR TITLE
Update to 1.12.10 (CVE-2019-16276)

### DIFF
--- a/notary-server/Dockerfile
+++ b/notary-server/Dockerfile
@@ -9,7 +9,7 @@ WORKDIR ${INSTALLDIR}
 
 RUN set -eux; \
     apk add --no-cache --virtual build-deps git go make musl-dev; \
-    go version | grep 'go1.12.8 '; \
+    go version | grep 'go1.12.10'; \
     export GOPATH=/go GOCACHE=/go/cache; \
     mkdir -p ${GOPATH}/src/${NOTARYPKG}; \
     git clone -b ${TAG} --depth 1 https://${NOTARYPKG} ${GOPATH}/src/${NOTARYPKG}; \

--- a/notary-signer/Dockerfile
+++ b/notary-signer/Dockerfile
@@ -10,7 +10,7 @@ WORKDIR ${INSTALLDIR}
 
 RUN set -eux; \
     apk add --no-cache --virtual build-deps git go make musl-dev; \
-    go version | grep 'go1.12.8 '; \
+    go version | grep 'go1.12.10'; \
     export GOPATH=/go GOCACHE=/go/cache; \
     mkdir -p ${GOPATH}/src/${NOTARYPKG}; \
     git clone -b ${TAG} --depth 1 https://${NOTARYPKG} ${GOPATH}/src/${NOTARYPKG}; \


### PR DESCRIPTION
Bump golang 1.12.10 (CVE-2019-16276)
-----------------------------------------------------

go1.12.10 (released 2019/09/25) includes security fixes to the net/http and net/textproto
packages. See the Go 1.12.10 milestone on our issue tracker for details.

https://github.com/golang/go/issues?q=milestone%3AGo1.12.10

Bump golang 1.12.9
-----------------------------------------------------

go1.12.9 (released 2019/08/15) includes fixes to the linker, and the os and math/big packages.
See the Go 1.12.9 milestone on our issue tracker for details.

https://github.com/golang/go/issues?q=milestone%3AGo1.12.9
