### PR TITLE
Add back space in validate step

### DIFF
--- a/notary-server/Dockerfile
+++ b/notary-server/Dockerfile
@@ -9,7 +9,7 @@ WORKDIR ${INSTALLDIR}
 
 RUN set -eux; \
     apk add --no-cache --virtual build-deps git go make musl-dev; \
-    go version | grep 'go1.12.10'; \
+    go version | grep 'go1.12.10 '; \
     export GOPATH=/go GOCACHE=/go/cache; \
     mkdir -p ${GOPATH}/src/${NOTARYPKG}; \
     git clone -b ${TAG} --depth 1 https://${NOTARYPKG} ${GOPATH}/src/${NOTARYPKG}; \

--- a/notary-signer/Dockerfile
+++ b/notary-signer/Dockerfile
@@ -10,7 +10,7 @@ WORKDIR ${INSTALLDIR}
 
 RUN set -eux; \
     apk add --no-cache --virtual build-deps git go make musl-dev; \
-    go version | grep 'go1.12.10'; \
+    go version | grep 'go1.12.10 '; \
     export GOPATH=/go GOCACHE=/go/cache; \
     mkdir -p ${GOPATH}/src/${NOTARYPKG}; \
     git clone -b ${TAG} --depth 1 https://${NOTARYPKG} ${GOPATH}/src/${NOTARYPKG}; \


### PR DESCRIPTION
This space looks to be intentional, to be sure we don't match, e.g. `go1.12.0-beta` when we _want_ `go1.12.0` "GA". Relates to https://github.com/docker/notary-official-images/pull/18#discussion_r335710441