### PR TITLE
version bump to 0.7.0

### DIFF
--- a/notary-server/Dockerfile
+++ b/notary-server/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:3.13
 
-ENV TAG v0.6.1
+ENV TAG v0.7.0
 ENV NOTARYPKG github.com/theupdateframework/notary
 ENV INSTALLDIR /notary/server
 EXPOSE 4443

--- a/notary-signer/Dockerfile
+++ b/notary-signer/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:3.13
 
-ENV TAG v0.6.1
+ENV TAG v0.7.0
 ENV NOTARYPKG github.com/theupdateframework/notary
 ENV INSTALLDIR /notary/signer
 EXPOSE 4444


### PR DESCRIPTION
Just a version bump, like what @thaJeztah ping about in https://github.com/docker/notary-official-images/pull/23#issuecomment-861868709

If acceptable, reminder to update https://github.com/docker-library/official-images/blob/master/library/notary after merge.