### PR TITLE
Update to alpine 3.15 and notary to v0.7.0

### DIFF
--- a/notary-server/Dockerfile
+++ b/notary-server/Dockerfile
@@ -1,6 +1,6 @@
-FROM alpine:3.13
+FROM alpine:3.15
 
-ENV TAG v0.6.1
+ENV TAG v0.7.0
 ENV NOTARYPKG github.com/theupdateframework/notary
 ENV INSTALLDIR /notary/server
 EXPOSE 4443

--- a/notary-signer/Dockerfile
+++ b/notary-signer/Dockerfile
@@ -1,6 +1,6 @@
-FROM alpine:3.13
+FROM alpine:3.15
 
-ENV TAG v0.6.1
+ENV TAG v0.7.0
 ENV NOTARYPKG github.com/theupdateframework/notary
 ENV INSTALLDIR /notary/signer
 EXPOSE 4444


### PR DESCRIPTION
- bump alpine to 3.15 (uses go 1.17)
- bump notary to the latest tag (v0.7.0)