### PR TITLE
Build Notary 0.7.0 using go 1.14

### DIFF
--- a/notary-server/Dockerfile
+++ b/notary-server/Dockerfile
@@ -1,29 +1,22 @@
-FROM alpine:3.12 as builder
+FROM alpine:3.12
 
 ENV TAG v0.7.0
 ENV NOTARYPKG github.com/theupdateframework/notary
 ENV INSTALLDIR /notary/server
+EXPOSE 4443
 
 WORKDIR ${INSTALLDIR}
 
 RUN set -eux; \
-    apk add git make go; \
+    apk add --no-cache --virtual build-deps git make go; \
     export GOPATH=/go GOCACHE=/go/cache; \
     mkdir -p ${GOPATH}/src/${NOTARYPKG}; \
     git clone -b ${TAG} --depth 1 https://${NOTARYPKG} ${GOPATH}/src/${NOTARYPKG}; \
     make -C ${GOPATH}/src/${NOTARYPKG} SKIPENVCHECK=1 PREFIX=. ./bin/static/notary-server; \
     cp -vL ${GOPATH}/src/${NOTARYPKG}/bin/static/notary-server ./; \
+    apk del --no-network build-deps; \
+    rm -rf ${GOPATH}; \
     ./notary-server --version
-
-FROM alpine:3.15
-
-ENV INSTALLDIR /notary/server
-
-EXPOSE 4443
-
-WORKDIR ${INSTALLDIR}
-
-COPY --from=builder ${INSTALLDIR}/notary-server .
 
 COPY ./server-config.json .
 COPY ./entrypoint.sh .

--- a/notary-server/Dockerfile
+++ b/notary-server/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.14-alpine3.13 as builder
+FROM alpine:3.12 as builder
 
 ENV TAG v0.7.0
 ENV NOTARYPKG github.com/theupdateframework/notary
@@ -7,7 +7,7 @@ ENV INSTALLDIR /notary/server
 WORKDIR ${INSTALLDIR}
 
 RUN set -eux; \
-    apk add git make; \
+    apk add git make go; \
     export GOPATH=/go GOCACHE=/go/cache; \
     mkdir -p ${GOPATH}/src/${NOTARYPKG}; \
     git clone -b ${TAG} --depth 1 https://${NOTARYPKG} ${GOPATH}/src/${NOTARYPKG}; \

--- a/notary-server/Dockerfile
+++ b/notary-server/Dockerfile
@@ -8,7 +8,7 @@ EXPOSE 4443
 WORKDIR ${INSTALLDIR}
 
 RUN set -eux; \
-    apk add --no-cache --virtual build-deps git make go; \
+    apk add --no-cache --virtual build-deps git go make musl-dev; \
     export GOPATH=/go GOCACHE=/go/cache; \
     mkdir -p ${GOPATH}/src/${NOTARYPKG}; \
     git clone -b ${TAG} --depth 1 https://${NOTARYPKG} ${GOPATH}/src/${NOTARYPKG}; \

--- a/notary-server/Dockerfile
+++ b/notary-server/Dockerfile
@@ -1,22 +1,29 @@
-FROM alpine:3.15
+FROM golang:1.14-alpine3.13 as builder
 
 ENV TAG v0.7.0
 ENV NOTARYPKG github.com/theupdateframework/notary
 ENV INSTALLDIR /notary/server
-EXPOSE 4443
 
 WORKDIR ${INSTALLDIR}
 
 RUN set -eux; \
-    apk add --no-cache --virtual build-deps git go make musl-dev; \
+    apk add git make; \
     export GOPATH=/go GOCACHE=/go/cache; \
     mkdir -p ${GOPATH}/src/${NOTARYPKG}; \
     git clone -b ${TAG} --depth 1 https://${NOTARYPKG} ${GOPATH}/src/${NOTARYPKG}; \
     make -C ${GOPATH}/src/${NOTARYPKG} SKIPENVCHECK=1 PREFIX=. ./bin/static/notary-server; \
     cp -vL ${GOPATH}/src/${NOTARYPKG}/bin/static/notary-server ./; \
-    apk del --no-network build-deps; \
-    rm -rf ${GOPATH}; \
-    ./notary-server --help
+    ./notary-server --version
+
+FROM alpine:3.15
+
+ENV INSTALLDIR /notary/server
+
+EXPOSE 4443
+
+WORKDIR ${INSTALLDIR}
+
+COPY --from=builder ${INSTALLDIR}/notary-server .
 
 COPY ./server-config.json .
 COPY ./entrypoint.sh .
@@ -26,4 +33,4 @@ USER notary
 ENV PATH=$PATH:${INSTALLDIR}
 
 ENTRYPOINT [ "entrypoint.sh" ]
-CMD [ "notary-server", "--help" ]
+CMD [ "notary-server", "--version" ]

--- a/notary-signer/Dockerfile
+++ b/notary-signer/Dockerfile
@@ -9,7 +9,7 @@ EXPOSE 7899
 WORKDIR ${INSTALLDIR}
 
 RUN set -eux; \
-    apk add --no-cache --virtual build-deps git make go; \
+    apk add --no-cache --virtual build-deps git go make musl-dev; \
     export GOPATH=/go GOCACHE=/go/cache; \
     mkdir -p ${GOPATH}/src/${NOTARYPKG}; \
     git clone -b ${TAG} --depth 1 https://${NOTARYPKG} ${GOPATH}/src/${NOTARYPKG}; \

--- a/notary-signer/Dockerfile
+++ b/notary-signer/Dockerfile
@@ -1,23 +1,30 @@
-FROM alpine:3.15
+FROM golang:1.14-alpine3.13 as builder
 
 ENV TAG v0.7.0
 ENV NOTARYPKG github.com/theupdateframework/notary
 ENV INSTALLDIR /notary/signer
-EXPOSE 4444
-EXPOSE 7899
 
 WORKDIR ${INSTALLDIR}
 
 RUN set -eux; \
-    apk add --no-cache --virtual build-deps git go make musl-dev; \
+    apk add git make; \
     export GOPATH=/go GOCACHE=/go/cache; \
     mkdir -p ${GOPATH}/src/${NOTARYPKG}; \
     git clone -b ${TAG} --depth 1 https://${NOTARYPKG} ${GOPATH}/src/${NOTARYPKG}; \
     make -C ${GOPATH}/src/${NOTARYPKG} SKIPENVCHECK=1 PREFIX=. ./bin/static/notary-signer; \
     cp -vL ${GOPATH}/src/${NOTARYPKG}/bin/static/notary-signer ./; \
-    apk del --no-network build-deps; \
-    rm -rf ${GOPATH}; \
-    ./notary-signer --help
+    ./notary-signer --version
+
+FROM alpine:3.15
+
+ENV INSTALLDIR /notary/signer
+
+EXPOSE 4444
+EXPOSE 7899
+
+WORKDIR ${INSTALLDIR}
+
+COPY --from=builder ${INSTALLDIR}/notary-signer .
 
 COPY ./signer-config.json .
 COPY ./entrypoint.sh .
@@ -27,4 +34,4 @@ USER notary
 ENV PATH=$PATH:${INSTALLDIR}
 
 ENTRYPOINT [ "entrypoint.sh" ]
-CMD [ "notary-signer", "--help" ]
+CMD [ "notary-signer", "--version" ]

--- a/notary-signer/Dockerfile
+++ b/notary-signer/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.14-alpine3.13 as builder
+FROM alpine:3.12 as builder
 
 ENV TAG v0.7.0
 ENV NOTARYPKG github.com/theupdateframework/notary
@@ -7,7 +7,7 @@ ENV INSTALLDIR /notary/signer
 WORKDIR ${INSTALLDIR}
 
 RUN set -eux; \
-    apk add git make; \
+    apk add git make go; \
     export GOPATH=/go GOCACHE=/go/cache; \
     mkdir -p ${GOPATH}/src/${NOTARYPKG}; \
     git clone -b ${TAG} --depth 1 https://${NOTARYPKG} ${GOPATH}/src/${NOTARYPKG}; \

--- a/notary-signer/Dockerfile
+++ b/notary-signer/Dockerfile
@@ -1,30 +1,23 @@
-FROM alpine:3.12 as builder
+FROM alpine:3.12
 
 ENV TAG v0.7.0
 ENV NOTARYPKG github.com/theupdateframework/notary
 ENV INSTALLDIR /notary/signer
-
-WORKDIR ${INSTALLDIR}
-
-RUN set -eux; \
-    apk add git make go; \
-    export GOPATH=/go GOCACHE=/go/cache; \
-    mkdir -p ${GOPATH}/src/${NOTARYPKG}; \
-    git clone -b ${TAG} --depth 1 https://${NOTARYPKG} ${GOPATH}/src/${NOTARYPKG}; \
-    make -C ${GOPATH}/src/${NOTARYPKG} SKIPENVCHECK=1 PREFIX=. ./bin/static/notary-signer; \
-    cp -vL ${GOPATH}/src/${NOTARYPKG}/bin/static/notary-signer ./; \
-    ./notary-signer --version
-
-FROM alpine:3.15
-
-ENV INSTALLDIR /notary/signer
-
 EXPOSE 4444
 EXPOSE 7899
 
 WORKDIR ${INSTALLDIR}
 
-COPY --from=builder ${INSTALLDIR}/notary-signer .
+RUN set -eux; \
+    apk add --no-cache --virtual build-deps git make go; \
+    export GOPATH=/go GOCACHE=/go/cache; \
+    mkdir -p ${GOPATH}/src/${NOTARYPKG}; \
+    git clone -b ${TAG} --depth 1 https://${NOTARYPKG} ${GOPATH}/src/${NOTARYPKG}; \
+    make -C ${GOPATH}/src/${NOTARYPKG} SKIPENVCHECK=1 PREFIX=. ./bin/static/notary-signer; \
+    cp -vL ${GOPATH}/src/${NOTARYPKG}/bin/static/notary-signer ./; \
+    apk del --no-network build-deps; \
+    rm -rf ${GOPATH}; \
+    ./notary-signer --version
 
 COPY ./signer-config.json .
 COPY ./entrypoint.sh .


### PR DESCRIPTION
Notary 0.7.0 needs to be build using go 1.14, but alpine 1.15 uses go 1.17

The issue in [notary is already fixed](https://github.com/notaryproject/notary/pull/1616) but it's not yet released.