### PR TITLE
Build via multi-stage, update to Go 1.19, Alpine 3.16

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,6 @@ jobs:
       - uses: actions/checkout@v3 # clone Notary upstream repo (used for generating necessary certificates to test against)
         with:
           repository: 'notaryproject/notary'
-          ref: 'v0.7.0'
+          ref: '74ee191c214795fb5e839bca841c7be2030d0002'
           path: 'notary-src'
       - run: NOTARY_SOURCE="$GITHUB_WORKSPACE/notary-src" ./.test/test.sh

--- a/notary-server/Dockerfile
+++ b/notary-server/Dockerfile
@@ -10,6 +10,13 @@ ENV GOFLAGS -mod=vendor
 WORKDIR /go/src/$NOTARYPKG
 RUN set -eux; \
 	git clone -b "$TAG" --depth 1 "https://$NOTARYPKG.git" .; \
+# https://github.com/notaryproject/notary/pull/1635
+	git fetch --depth 2 origin efc35b02698644af16f6049c7b585697352451b8; \
+	git -c user.name=foo -c user.email=foo@example.com cherry-pick -x efc35b02698644af16f6049c7b585697352451b8; \
+# https://github.com/notaryproject/notary/issues/1602 (rough cherry-pick of ca095023296d2d710ad9c6dec019397d46bf8576)
+	go get github.com/dvsekhvalnov/jose2go@v0.0.0-20200901110807-248326c1351b; \
+	go mod vendor; \
+# TODO remove for the next release of Notary (which should include efc35b02698644af16f6049c7b585697352451b8 & ca095023296d2d710ad9c6dec019397d46bf8576)
 	make SKIPENVCHECK=1 PREFIX=. ./bin/static/notary-server ./bin/static/notary-signer; \
 	cp -vL ./bin/static/notary-server ./bin/static/notary-signer /; \
 	/notary-server --version; \

--- a/notary-server/Dockerfile
+++ b/notary-server/Dockerfile
@@ -1,29 +1,36 @@
-FROM alpine:3.12
+FROM golang:1.19-alpine3.16 AS build
 
-ENV TAG v0.7.0
+RUN apk add --no-cache git make
+
 ENV NOTARYPKG github.com/theupdateframework/notary
-ENV INSTALLDIR /notary/server
+ENV TAG v0.7.0
+
+ENV GOFLAGS -mod=vendor
+
+WORKDIR /go/src/$NOTARYPKG
+RUN set -eux; \
+	git clone -b "$TAG" --depth 1 "https://$NOTARYPKG.git" .; \
+	make SKIPENVCHECK=1 PREFIX=. ./bin/static/notary-server ./bin/static/notary-signer; \
+	cp -vL ./bin/static/notary-server ./bin/static/notary-signer /; \
+	/notary-server --version; \
+	/notary-signer --version
+
+FROM alpine:3.16
+
+RUN adduser -D -H -g "" notary
 EXPOSE 4443
 
+ENV INSTALLDIR /notary/server
+ENV PATH=$PATH:${INSTALLDIR}
 WORKDIR ${INSTALLDIR}
 
-RUN set -eux; \
-    apk add --no-cache --virtual build-deps git go make musl-dev; \
-    export GOPATH=/go GOCACHE=/go/cache; \
-    mkdir -p ${GOPATH}/src/${NOTARYPKG}; \
-    git clone -b ${TAG} --depth 1 https://${NOTARYPKG} ${GOPATH}/src/${NOTARYPKG}; \
-    make -C ${GOPATH}/src/${NOTARYPKG} SKIPENVCHECK=1 PREFIX=. ./bin/static/notary-server; \
-    cp -vL ${GOPATH}/src/${NOTARYPKG}/bin/static/notary-server ./; \
-    apk del --no-network build-deps; \
-    rm -rf ${GOPATH}; \
-    ./notary-server --version
+COPY --from=build /notary-server ./
+RUN ./notary-server --version
 
 COPY ./server-config.json .
 COPY ./entrypoint.sh .
 
-RUN adduser -D -H -g "" notary
 USER notary
-ENV PATH=$PATH:${INSTALLDIR}
 
 ENTRYPOINT [ "entrypoint.sh" ]
 CMD [ "notary-server", "--version" ]

--- a/notary-signer/Dockerfile
+++ b/notary-signer/Dockerfile
@@ -10,6 +10,13 @@ ENV GOFLAGS -mod=vendor
 WORKDIR /go/src/$NOTARYPKG
 RUN set -eux; \
 	git clone -b "$TAG" --depth 1 "https://$NOTARYPKG.git" .; \
+# https://github.com/notaryproject/notary/pull/1635
+	git fetch --depth 2 origin efc35b02698644af16f6049c7b585697352451b8; \
+	git -c user.name=foo -c user.email=foo@example.com cherry-pick -x efc35b02698644af16f6049c7b585697352451b8; \
+# https://github.com/notaryproject/notary/issues/1602 (rough cherry-pick of ca095023296d2d710ad9c6dec019397d46bf8576)
+	go get github.com/dvsekhvalnov/jose2go@v0.0.0-20200901110807-248326c1351b; \
+	go mod vendor; \
+# TODO remove for the next release of Notary (which should include efc35b02698644af16f6049c7b585697352451b8 & ca095023296d2d710ad9c6dec019397d46bf8576)
 	make SKIPENVCHECK=1 PREFIX=. ./bin/static/notary-server ./bin/static/notary-signer; \
 	cp -vL ./bin/static/notary-server ./bin/static/notary-signer /; \
 	/notary-server --version; \

--- a/notary-signer/Dockerfile
+++ b/notary-signer/Dockerfile
@@ -1,30 +1,37 @@
-FROM alpine:3.12
+FROM golang:1.19-alpine3.16 AS build
 
-ENV TAG v0.7.0
+RUN apk add --no-cache git make
+
 ENV NOTARYPKG github.com/theupdateframework/notary
-ENV INSTALLDIR /notary/signer
+ENV TAG v0.7.0
+
+ENV GOFLAGS -mod=vendor
+
+WORKDIR /go/src/$NOTARYPKG
+RUN set -eux; \
+	git clone -b "$TAG" --depth 1 "https://$NOTARYPKG.git" .; \
+	make SKIPENVCHECK=1 PREFIX=. ./bin/static/notary-server ./bin/static/notary-signer; \
+	cp -vL ./bin/static/notary-server ./bin/static/notary-signer /; \
+	/notary-server --version; \
+	/notary-signer --version
+
+FROM alpine:3.16
+
+RUN adduser -D -H -g "" notary
 EXPOSE 4444
 EXPOSE 7899
 
+ENV INSTALLDIR /notary/signer
+ENV PATH=$PATH:${INSTALLDIR}
 WORKDIR ${INSTALLDIR}
 
-RUN set -eux; \
-    apk add --no-cache --virtual build-deps git go make musl-dev; \
-    export GOPATH=/go GOCACHE=/go/cache; \
-    mkdir -p ${GOPATH}/src/${NOTARYPKG}; \
-    git clone -b ${TAG} --depth 1 https://${NOTARYPKG} ${GOPATH}/src/${NOTARYPKG}; \
-    make -C ${GOPATH}/src/${NOTARYPKG} SKIPENVCHECK=1 PREFIX=. ./bin/static/notary-signer; \
-    cp -vL ${GOPATH}/src/${NOTARYPKG}/bin/static/notary-signer ./; \
-    apk del --no-network build-deps; \
-    rm -rf ${GOPATH}; \
-    ./notary-signer --version
+COPY --from=build /notary-signer ./
+RUN ./notary-signer --version
 
 COPY ./signer-config.json .
 COPY ./entrypoint.sh .
 
-RUN adduser -D -H -g "" notary
 USER notary
-ENV PATH=$PATH:${INSTALLDIR}
 
 ENTRYPOINT [ "entrypoint.sh" ]
 CMD [ "notary-signer", "--version" ]


### PR DESCRIPTION
This is possible now thanks to https://github.com/docker-library/bashbrew/pull/43 -- there are some more dependencies before we can take this all the way linked from https://github.com/docker-library/bashbrew/pull/43#issuecomment-1278331278, but we're close enough that we can start testing at this level. :+1: